### PR TITLE
Fix build errors and enable viewBinding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,9 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    viewBinding {
+        enable = true
+    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,12 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion(34)
+    namespace = "com.example.arbeid"
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.arbeid"
-        minSdkVersion(21)
-        targetSdkVersion(32)
+        minSdk = 21
+        targetSdk = 32
         versionCode = 1
         versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         applicationId = "com.example.arbeid"
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 32 /* TODO: Review the targeted SDK version */
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/java/com/example/arbeid/MainActivity.kt
+++ b/app/src/main/java/com/example/arbeid/MainActivity.kt
@@ -1,11 +1,15 @@
 package com.example.arbeid
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.arbeid.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 }


### PR DESCRIPTION
When checking the MainActivity class at the package directory, i noticed something odd. Inside the setContentView method at the onCreate function, the root class (R) wasn't being properly recognized, with Android Studio displaying a very annoying error. When trying to rewrite it and following the IDE's context actions, it simply imported the root from "missing.namespace.R", as if the package wasn't properly loaded. The code was the following:

```kt
package com.example.arbeid

import androidx.appcompat.app.AppCompatActivity
import android.os.Bundle
import missing.namespace.R

class MainActivity : AppCompatActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)
    }
}
```

After checking AndroidManifest.xml to see if i could find any answers, weirdly enough, the parameter to set the name of an activity - in this case, `android:name=".MainActivity"` - also displayed an error, as the activity didn't exist at all. Finally, after checking activity_main.xml at the layout folder and finding the same issue, and attemping to rebuild the project at a separate patch branch, i finally found the problem. The namespace wasn't defined at all on the Gradle build files, so i just wrote `namespace = "com.example.arbeid"`.

I think it would be interesting to check for the same build error at the back-end branch too.