### PR TITLE
Add 13 colors in colors.xml

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- PRIMARY: -->
+    <color name="blue">#FF0F1C4D</color>
+    <color name="red">#FFFC0A0A</color>
+    <color name="orange">#FFEF4706</color>
+    <color name="yellow">#FFEE9E02</color>
+
+    <!-- SECONDARY: -->
+    <color name="dark_blue">#020027</color>
+    <color name="light_blue">#395094</color>
+    <color name="blue_transparent">#800F1D4E</color>
+    <color name="orange_transparent">#80EF4706</color>
+
+    <!-- NEUTRAL: -->
     <color name="black">#FF000000</color>
+    <color name="dark_grey">#FF555555</color>
+    <color name="grey">#66E8E8E8</color> <!-- Will start with "#FF..." outside of the Register activity -->
+    <color name="light_grey">#CCE2E2E2</color> <!-- Will start with "#FF..." outside of the Register activity -->
     <color name="white">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
Greetings José,

For the integrity of this project and commitment to the high-fidelity design prototype, I decided to store the main colors of the app (excluding filler fields and elements) on its designated configuration file, ` app/src/main/res/values/colors.xml `. The colors added could be classified as the following:

1. **Primary Colors:** Main colors of the project, being varsely repeated accross all activities, fragments and design components.
5. **Secondary Colors:** Usually derived from the primary colors, they are utilized for adding variety and/or representing components which cannot be of a primary color. Examples include progress bars, gradient backgrounds, drawables, active menu selectors, etc.
6. **Neutral Colors:** Section composed of monochrome, black-to-white color shades. Its values are frequently utilized for borders, (main) backgrounds, simple text/paragraph boxes, section breaks, empty elements to be filled, etc.